### PR TITLE
Smaller Dep Updates - No breaks :)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <dependency>
       <groupId>org.snmp4j</groupId>
       <artifactId>snmp4j</artifactId>
-      <version>2.8.4</version>
+      <version>2.8.12</version>
       <exclusions>
         <exclusion>
           <groupId>log4j</groupId>
@@ -96,16 +96,19 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
+      <version>1.2.11</version>
       <scope>runtime</scope>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.jmock</groupId>
       <artifactId>jmock-junit4</artifactId>
+      <version>2.12.0</version>
     </dependency>
     <dependency>
       <groupId>org.jmock</groupId>
       <artifactId>jmock-legacy</artifactId>
+      <version>2.12.0</version>
     </dependency>
   </dependencies>
   <repositories>

--- a/src/test/java/org/soulwing/snmp/SnmpV2cAsyncDemo.java
+++ b/src/test/java/org/soulwing/snmp/SnmpV2cAsyncDemo.java
@@ -25,7 +25,7 @@ public class SnmpV2cAsyncDemo {
   private static final String NOT_AVAILABLE = "N/A";
   
   private static final Pattern CISCOIOS_PATTERN =
-      Pattern.compile("Software \\(([^)]+)\\).*Version  *([^ ,]+) *");
+      Pattern.compile("Software \\(([^)]+)\\).*Version +([^ ,]+) *");
   
   public static void main(String[] args) throws Exception {    
     final String deviceName = System.getProperty("agent.name", "foo");
@@ -42,7 +42,7 @@ public class SnmpV2cAsyncDemo {
     SnmpContext snmp = SnmpFactory.getInstance().newContext(target, mib);
 
     SnmpCompletionService<VarbindCollection> completionService =
-        new BlockingQueueSnmpCompletionService<VarbindCollection>();
+            new BlockingQueueSnmpCompletionService<>();
 
     completionService.submit(snmp.newGetNext("sysDescr", "sysUpTime"));
     while (!completionService.isIdle()) {

--- a/src/test/java/org/soulwing/snmp/SnmpV2cDemo.java
+++ b/src/test/java/org/soulwing/snmp/SnmpV2cDemo.java
@@ -25,7 +25,7 @@ public class SnmpV2cDemo {
   private static final String NOT_AVAILABLE = "N/A";
   
   private static final Pattern CISCOIOS_PATTERN =
-      Pattern.compile("Software \\(([^)]+)\\).*Version  *([^ ,]+) *");
+      Pattern.compile("Software \\(([^)]+)\\).*Version +([^ ,]+) *");
   
   public static void main(String[] args) throws Exception {
     final String deviceName = System.getProperty("agent.name", "foo");


### PR DESCRIPTION
Near as I can tell, nothing breaks when updating these packages. All of the tests that I could run passed. I could not run the listener test.

Much smaller version upgrade this time for SNMP4J. This PR updates logback to remove the vulnerability it possessed. 

If I knew more about JUnit I'd move that to Jupiter for you, but writing tests is something I'm still a novice regarding.